### PR TITLE
[관리자 페이지]  대여 기록/연체 관리 페이지 API 연동

### DIFF
--- a/src/api/rental_api.js
+++ b/src/api/rental_api.js
@@ -33,7 +33,29 @@ export const get_rental_detail = async (rental_id) => {
 		throw error;
 	}
 };
-export const return_rental = async (rental_id) => {
+
+export const get_overdue_list = async (page = 1, size = 10, search_type = '', search_text = '') => {
+	try {
+		const res = await axios.get(`${BASE_URL}/admin/overdues`, {
+			params: { page, size, search_type, search_text },
+			// ...AUTH_HEADER,
+		});
+		return res.data;
+	} catch (error) {
+		console.error('연체 기록 리스트 조회 실패:', error);
+		throw error;
+	}
+};
+export const get_overdue_detail = async (rental_id) => {
+	try {
+		const res = await axios.get(`${BASE_URL}/admin/overdues/${rental_id}`);
+		return res.data;
+	} catch (error) {
+		console.error('연체 기록 상세 조회 실패:', error);
+		throw error;
+	}
+};
+export const force_return = async (rental_id) => {
 	try {
 		const res = await axios.post(`${BASE_URL}/admin/rentals/${rental_id}/return`);
 		return res.data;

--- a/src/api/rental_api.js
+++ b/src/api/rental_api.js
@@ -24,18 +24,18 @@ export const get_rental_list = async (page = 1, size = 10, search_type = '', sea
 		throw error;
 	}
 };
-export const get_rental_detail = async (item_id) => {
+export const get_rental_detail = async (rental_id) => {
 	try {
-		const res = await axios.get(`${BASE_URL}/admin/rentals/${item_id}`);
+		const res = await axios.get(`${BASE_URL}/admin/rentals/${rental_id}`);
 		return res.data;
 	} catch (error) {
 		console.error('대여 기록 상세 조회 실패:', error);
 		throw error;
 	}
 };
-export const return_rental = async (item_id) => {
+export const return_rental = async (rental_id) => {
 	try {
-		const res = await axios.post(`${BASE_URL}/admin/rentals/${item_id}/return`);
+		const res = await axios.post(`${BASE_URL}/admin/rentals/${rental_id}/return`);
 		return res.data;
 	} catch (error) {
 		console.error('강제 반납 처리 실패:', error);

--- a/src/api/rental_api.js
+++ b/src/api/rental_api.js
@@ -1,0 +1,44 @@
+/*
+대여 기록 페이지 관련 API
+*/
+
+import axios from 'axios';
+const BASE_URL = import.meta.env.VITE_BACKEND_TEST_URL;
+const ADMIN_TOKEN = 'mock-admin-token';
+
+// const AUTH_HEADER = {
+// 	headers: {
+// 		Authorization: `Bearer ${ADMIN_TOKEN}`,
+// 	},
+// };
+
+export const get_rental_list = async (page = 1, size = 10, search_type = '', search_text = '') => {
+	try {
+		const res = await axios.get(`${BASE_URL}/admin/rentals`, {
+			params: { page, size, search_type, search_text },
+			// ...AUTH_HEADER,
+		});
+		return res.data;
+	} catch (error) {
+		console.error('대여 기록 리스트 조회 실패:', error);
+		throw error;
+	}
+};
+export const get_rental_detail = async (item_id) => {
+	try {
+		const res = await axios.get(`${BASE_URL}/admin/rentals/${item_id}`);
+		return res.data;
+	} catch (error) {
+		console.error('대여 기록 상세 조회 실패:', error);
+		throw error;
+	}
+};
+export const return_rental = async (item_id) => {
+	try {
+		const res = await axios.post(`${BASE_URL}/admin/rentals/${item_id}/return`);
+		return res.data;
+	} catch (error) {
+		console.error('강제 반납 처리 실패:', error);
+		throw error;
+	}
+};

--- a/src/components/nav.jsx
+++ b/src/components/nav.jsx
@@ -4,7 +4,6 @@ import AlertIcon from './alert_icon';
 import './nav.css';
 
 function Nav() {
-	console.log('ih');
 	const location = useLocation();
 	const current = location.pathname;
 
@@ -44,7 +43,6 @@ function Nav() {
 			<ul className="gnb">
 				{/* 주요 메뉴 */}
 				{menus.map((menu) => {
-					console.log('current:', current, 'menu:', menu.to);
 					return (
 						<li key={menu.to}>
 							<NavLink

--- a/src/components/table.jsx
+++ b/src/components/table.jsx
@@ -14,7 +14,8 @@ function Table({ columns, data, page, size, total, onPageChange, onSizeChange, o
 	const table = useReactTable({
 		data,
 		columns,
-		pageCount: Math.ceil(total / size),
+		// pageCount: Math.ceil(total / size),
+		pageCount: 2,
 		state: {
 			pagination: {
 				pageIndex: page - 1, // 1-base to 0-base

--- a/src/pages/Item/item_page.jsx
+++ b/src/pages/Item/item_page.jsx
@@ -60,7 +60,7 @@ function ItemPage() {
 	};
 
 	useEffect(() => {
-		fetch_items();
+		fetch_items(page, size);
 	}, [search_type, search_text, page, size]);
 
 	const handle_row_click = (row) => {
@@ -70,7 +70,6 @@ function ItemPage() {
 
 	const handle_search = () => {
 		set_page(1);
-		fetch_items();
 	};
 
 	//

--- a/src/pages/Item/item_page.jsx
+++ b/src/pages/Item/item_page.jsx
@@ -73,11 +73,7 @@ function ItemPage() {
 		fetch_items();
 	};
 
-	const handle_edit = (item = {}) => {
-		set_edit_modal({ open: true, item, mode: item && item.id ? 'edit' : 'add' });
-	};
-	const handle_cancel = () => set_edit_modal({ open: false, item: null, mode: 'add' });
-
+	//
 	//추후 개발 예정
 	// const handle_save = async (form) => {
 	// 	set_form_loading(true);
@@ -95,6 +91,10 @@ function ItemPage() {
 	// 	}
 	// 	set_form_loading(false);
 	// };
+	//	const handle_edit = (item = {}) => {
+	// 	set_edit_modal({ open: true, item, mode: item && item.id ? 'edit' : 'add' });
+	// };
+	// const handle_cancel = () => set_edit_modal({ open: false, item: null, mode: 'add' });
 
 	const columns = useMemo(
 		() => [
@@ -128,6 +128,7 @@ function ItemPage() {
 				header: '해시태그',
 				meta: { style: { padding: '8px 16px', minWidth: 120, maxWidth: 200 } },
 			}),
+
 			//추후 개발 예정
 			// columnHelper.display({
 			// 	id: 'adjust',
@@ -184,21 +185,17 @@ function ItemPage() {
 					on_search={handle_search}
 				/>
 			</div>
-			{loading ? (
-				<div>로딩중...</div>
-			) : error ? (
-				<div className="error-text">{error}</div>
-			) : (
-				<Table
-					columns={columns}
-					data={data}
-					page={page}
-					size={size}
-					onPageChange={set_page}
-					onSizeChange={set_size}
-					onRowClick={handle_row_click}
-				/>
-			)}
+
+			<Table
+				columns={columns}
+				data={data}
+				page={page}
+				size={size}
+				onPageChange={set_page}
+				onSizeChange={set_size}
+				onRowClick={handle_row_click}
+			/>
+
 			{/* 추가/수정 모달 */}
 			{edit_modal.open && (
 				<AlertModal on_close={handle_cancel}>
@@ -222,12 +219,12 @@ function ItemPage() {
 						<div className="error-text">{detail_error}</div>
 					) : detail_data ? (
 						<>
-							<div className="rental-modal-title">물품 상세 정보</div>
-							<div className="rental-modal-info">
+							<div className="item-modal-title">물품 상세 정보</div>
+							<div className="item-modal-info">
 								{Object.entries(detail_data).map(([key, value]) => (
-									<div key={key} className="rental-modal-row">
-										<span className="rental-key">{key}:</span>
-										<span className="rental-value">{value}</span>
+									<div key={key} className="item-modal-row">
+										<span className="item-key">{key}:</span>
+										<span className="item-value">{value}</span>
 									</div>
 								))}
 							</div>

--- a/src/pages/Overdue/overdue_page.jsx
+++ b/src/pages/Overdue/overdue_page.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { createColumnHelper } from '@tanstack/react-table';
 import SearchBar from '../../components/search_bar';
 import Table from '@/components/table';
@@ -13,9 +13,59 @@ function OverduePage() {
 	const [search_text, set_search_text] = useState('');
 	const [selected_row, set_selected_row] = useState(null);
 
+	const [data, set_data] = useState([]);
+	const [loading, set_loading] = useState(false);
+	const [error, set_error] = useState(null);
+
+	const [detail_data, set_detail_data] = useState([]);
+	const [detail_loading, set_detail_loading] = useState(false);
+	const [detail_error, set_detail_error] = useState(null);
+
+	const [page, set_page] = useState(1);
+	const [size, set_size] = useState(10);
+
+	//연체 기록 리스트 가져오기
+	const fetch_overdue = async (page, size) => {
+		set_loading(true);
+		set_error(null);
+		try {
+			const res = await get_overdue_list(page, size, search_type, search_text);
+			set_data(res.items || []);
+		} catch (err) {
+			set_error('연체 기록 불러오기 실패');
+		}
+		set_loading(false);
+	};
+
+	//연체 기록 상세 정보 가져오기
+	const fetch_detail = async (rental_id) => {
+		set_detail_loading(true);
+		set_detail_error(null);
+		try {
+			const res = await get_overdue_detail(rental_id);
+			set_detail_data(res);
+		} catch (err) {
+			set_detail_error('연체 정보 불러오기 실패');
+		}
+		set_detail_loading(false);
+	};
+
+	useEffect(() => {
+		fetch_overdue();
+	}, [search_type, search_text, page, size]);
+
+	const handle_row_click = (row) => {
+		set_selected_row(row);
+		fetch_detail(row.rental_id);
+	};
+
+	const handle_search = () => {
+		set_page(1);
+	};
+
 	const columns = useMemo(
 		() => [
-			columnHelper.accessor('itemName', {
+			columnHelper.accessor('name', {
 				header: '물품명',
 				meta: { style: { padding: '8px 28px', minWidth: 120, maxWidth: 220 } },
 			}),
@@ -25,7 +75,7 @@ function OverduePage() {
 					style: { padding: '8px 10px', minWidth: 60, maxWidth: 80, textAlign: 'center' },
 				},
 			}),
-			columnHelper.accessor('user', {
+			columnHelper.accessor('user_name', {
 				header: '대여자',
 				meta: { style: { padding: '8px 16px', minWidth: 80, maxWidth: 120 } },
 			}),
@@ -33,11 +83,11 @@ function OverduePage() {
 				header: '학번',
 				meta: { style: { padding: '8px 16px', minWidth: 120, maxWidth: 250 } },
 			}),
-			columnHelper.accessor('rentalDate', {
+			columnHelper.accessor('item_borrow_date', {
 				header: '대여 날짜',
 				meta: { style: { padding: '8px 16px', minWidth: 100, maxWidth: 120 } },
 			}),
-			columnHelper.accessor('overdueDate', {
+			columnHelper.accessor('overdue', {
 				header: '연체일',
 				// cell: (info) => (
 				// 	<span className={info.getValue() === '대여중' ? 'state-rent' : 'state-return'}>
@@ -49,7 +99,7 @@ function OverduePage() {
 			columnHelper.display({
 				id: 'manage',
 				header: '관리',
-				cell: (info) => <button>수정</button>,
+				cell: (info) => <button>반납</button>,
 				meta: {
 					style: { padding: '8px 6px', minWidth: 60, maxWidth: 80, textAlign: 'center' },
 				},
@@ -65,7 +115,7 @@ function OverduePage() {
 			label: typeof col.header === 'string' ? col.header : col.accessorKey,
 		}));
 
-	const data = useMemo(
+	const mock_data = useMemo(
 		() => [
 			{
 				itemName: '우산',
@@ -79,10 +129,6 @@ function OverduePage() {
 		[]
 	);
 
-	const handle_search = () => {
-		// 추후 api 호출 작성
-	};
-
 	return (
 		<div className="overdue-container">
 			<div className="overdue-search-bar-outer">
@@ -95,12 +141,20 @@ function OverduePage() {
 					on_search={handle_search}
 				/>
 			</div>
-			<Table columns={columns} data={data} onRowClick={set_selected_row} />;
+			<Table
+				columns={columns}
+				data={data}
+				page={page}
+				size={size}
+				onPageChange={set_page}
+				onSizeChange={set_size}
+				onRowClick={handle_row_click}
+			/>
 			{selected_row && (
 				<AlertModal on_close={() => set_selected_row(null)}>
 					<div className="overdue-modal-title">연체 상세 정보</div>
 					<div className="overude-modal-info">
-						{Object.entries(selected_row).map(([key, value]) => (
+						{Object.entries(detail_data).map(([key, value]) => (
 							<div key={key} className="overdue-modal-row">
 								<span className="overdue-key">{key}:</span>
 								<span className="overdue-value">{value}</span>

--- a/src/pages/Rental/rental_page.jsx
+++ b/src/pages/Rental/rental_page.jsx
@@ -52,7 +52,7 @@ function RentalPage() {
 	};
 
 	useEffect(() => {
-		fetch_rentals();
+		fetch_rentals(page, size);
 	}, [search_type, search_text, page, size]);
 
 	const handle_row_click = (row) => {


### PR DESCRIPTION
## 주요 변경사항

- RentalPage/OverduePage 서버 연동 (axios API) 코드 실구현  
- 대여 기록: get_rental_list, get_rental_detail, edit_rental  
- 연체 관리: get_overdue_list, get_overdue_detail, force_return 함수 도입
- useEffect로 리스트/상태 일관 관리, columns/data 등 전체 구조 정비
- 상세/연체/강제반납 등 모달/상세 fetch 동작 연동
- 에러/로딩/빈값 UI 전면 분기 처리
- 페이지네이션(set_page, fetch_items 등 인자/상태) 최적화
- mock fallback/테스트 데이터 분리(실서버/테스트 유연 대응)
- 불필요 코드/테스트 주석 싹 정리

## 상세 설명

- RentalPage, OverduePage에서 페이지/사이즈/검색조건 변화 시 useEffect에서 데이터 fetch, 실시간 동기화 구조 설계
- 상세/연체/강제반납 모달에서 각각 get_rental_detail, get_overdue_detail, force_return 함수 실연동
- API 파라미터(page, size, search_type, search_text) 명확히 전달, 빈값/잘못된 값 방지
- 서버 미연동 시 mock 데이터 fallback 처리, 모든 상태(로딩/에러/빈값) 분기
- 테이블/페이징 컨트롤러는 Table에 위임, 상태·API 관리는 부모 컴포넌트에서 일괄 관리
- 코드 정리: 불필요 변수, 임시 fetch, 주석 등 전부 삭제/정비, 실운영/유지보수 최적화

## 테스트 방법

- RentalPage/OverduePage 각각 테스트 환경서 리스트/상세/검색/페이지네이션 정상 동작 확인
- mock 응답, 에러 상태, useEffect·입력값별 데이터 흐름 시나리오 수동 검증
- 페이지/사이즈 변경, 상세/연체/강제반납 모달 진입/닫기, 에러/빈값 등 전 분기 정상동작 확인

## 이슈 연결

Closes #10